### PR TITLE
Replace @Path by @Resource and @Endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+.settings
+**/*.iml

--- a/core/src/main/java/org/seedtray/rest/HttpMethod.java
+++ b/core/src/main/java/org/seedtray/rest/HttpMethod.java
@@ -1,0 +1,52 @@
+package org.seedtray.rest;
+
+/**
+ * Standard HTTP methods.
+ * @see <a href="http://www.ietf.org/rfc/rfc2616.txt">RFC 2616</a>
+ */
+public class HttpMethod {
+
+  private HttpMethod() {
+  }
+
+  /**
+   * HTTP GET method.
+   */
+  public static final String GET = "GET";
+
+  /**
+   * HTTP POST method.
+   */
+  public static final String POST = "POST";
+
+  /**
+   * HTTP PUT method.
+   */
+  public static final String PUT = "PUT";
+
+  /**
+   * HTTP DELETE method.
+   */
+  public static final String DELETE = "DELETE";
+
+  /**
+   * HTTP HEAD method.
+   */
+  public static final String HEAD = "HEAD";
+
+  /**
+   * HTTP OPTIONS method.
+   */
+  public static final String OPTIONS = "OPTIONS";
+
+  /**
+   * HTTP TRACE method.
+   */
+  public static final String TRACE = "TRACE";
+
+  /**
+   * HTTP CONNECT method.
+   */
+  public static final String CONNECT = "CONNECT";
+
+}

--- a/core/src/main/java/org/seedtray/rest/annotation/Endpoint.java
+++ b/core/src/main/java/org/seedtray/rest/annotation/Endpoint.java
@@ -14,6 +14,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Documented
 public @interface Endpoint {
+  /**
+   * Typically one of the standard HTTP methods defined in {@link org.seedtray.rest.HttpMethod}.
+   */
   String method();
+
+  /**
+   * A relative path within this resource that is mapped to the annotated method.
+   */
   String path();
 }

--- a/core/src/main/java/org/seedtray/rest/annotation/Endpoint.java
+++ b/core/src/main/java/org/seedtray/rest/annotation/Endpoint.java
@@ -1,0 +1,19 @@
+package org.seedtray.rest.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation for methods of a {@link Resource} class.
+ */
+@Target(ElementType.METHOD)
+@Retention(RUNTIME)
+@Documented
+public @interface Endpoint {
+  String method();
+  String path();
+}

--- a/core/src/main/java/org/seedtray/rest/annotation/Resource.java
+++ b/core/src/main/java/org/seedtray/rest/annotation/Resource.java
@@ -2,15 +2,17 @@ package org.seedtray.rest.annotation;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * A URL pattern path.
+ * Annotation for REST resources.
  */
-@Target({ ElementType.TYPE, ElementType.METHOD })
+@Target(ElementType.TYPE)
 @Retention(RUNTIME)
-public @interface Path {
+@Documented
+public @interface Resource {
   String value();
 }

--- a/core/src/test/java/META-INF/MANIFEST.MF
+++ b/core/src/test/java/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Class-Path: 
+

--- a/sampleApp/src/main/java/org/seedtray/rest/sample/IdResource.java
+++ b/sampleApp/src/main/java/org/seedtray/rest/sample/IdResource.java
@@ -1,12 +1,14 @@
 package org.seedtray.rest.sample;
 
+import org.seedtray.rest.HttpMethod;
 import org.seedtray.rest.UrlPattern.Parameters;
-import org.seedtray.rest.annotation.Path;
+import org.seedtray.rest.annotation.Endpoint;
+import org.seedtray.rest.annotation.Resource;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
-@Path("/{id}")
+@Resource("/{id}")
 public class IdResource {
 
   private final Provider<Parameters> matchResult;
@@ -16,8 +18,8 @@ public class IdResource {
     this.matchResult = matchResult;
   }
 
-  @Path("/get")
+  @Endpoint(method = HttpMethod.GET, path = "/get")
   public void getId() {
-    System.out.println("Holaaaaa " + matchResult.get().getParameter("id") + "!!");
+    System.out.println("id is " + matchResult.get().getParameter("id"));
   }
 }

--- a/sampleApp/src/main/java/org/seedtray/rest/sample/SampleModule.java
+++ b/sampleApp/src/main/java/org/seedtray/rest/sample/SampleModule.java
@@ -8,14 +8,12 @@ public class SampleModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    install(new SampleRestModule());
-  }
-
-  public static class SampleRestModule extends RestModule {
-    @Override
-    protected void configureResources() {
-      serveResource(IdResource.class);
-    }
+    install(new RestModule() {
+      @Override
+      protected void configureResources() {
+        serveResource(IdResource.class);
+      }
+    });
   }
 
 }


### PR DESCRIPTION
Instead of using @Path as the only annotation for a resource class we now have
@Resource for the class which provides the base path and @Endpoint for methods
that specifies the HTTP method and the relative path.
